### PR TITLE
Fix streamlit import error

### DIFF
--- a/csv_xls_analyse/streamlit_app.py
+++ b/csv_xls_analyse/streamlit_app.py
@@ -1,7 +1,11 @@
 import io
 import streamlit as st
 
-from .core import merge_csv_files, create_export_excel, analyse_consumption
+from csv_xls_analyse.core import (
+    merge_csv_files,
+    create_export_excel,
+    analyse_consumption,
+)
 
 
 def main():


### PR DESCRIPTION
## Summary
- use an absolute import in `streamlit_app.py` so the app works when executed directly

## Testing
- `python -m py_compile csv_xls_analyse/streamlit_app.py`
- `python -m csv_xls_analyse.streamlit_app` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684a9c18da08832da4b31b60aa23f54f