### PR TITLE
Fix deprecation warning in CSV parsing

### DIFF
--- a/app.py
+++ b/app.py
@@ -19,7 +19,10 @@ def read_csv_file(file_data) -> pd.DataFrame:
         if df[col].str.contains(",").any():
             df[col] = df[col].str.replace(" ", "")
             df[col] = df[col].str.replace(",", ".")
-            df[col] = pd.to_numeric(df[col], errors="ignore")
+            try:
+                df[col] = pd.to_numeric(df[col])
+            except (ValueError, TypeError):
+                pass
     return df
 
 


### PR DESCRIPTION
## Summary
- remove deprecated `errors="ignore"` from `pd.to_numeric`
- handle conversion errors via try/except

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684acd9c66c8832d9a049877118a2f77