### PR TITLE
Remove per-file sheets from Excel output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CSV/XLS Analyse
 
-Cette application Streamlit permet d’importer plusieurs fichiers CSV ou ZIP, de fusionner les données et de télécharger un classeur Excel multi-feuilles généré en mémoire.
+Cette application Streamlit permet d’importer plusieurs fichiers CSV ou ZIP, de fusionner les données et de télécharger un fichier Excel contenant une seule feuille "Fusion" regroupant toutes les données.
 
 ## Prérequis
 

--- a/app.py
+++ b/app.py
@@ -46,20 +46,15 @@ def main():
     if uploaded_files:
         if st.button("Lancer la conversion"):
             all_dfs = []
-            file_sheets = {}
             for up_file in uploaded_files:
                 filename = up_file.name
                 if filename.lower().endswith(".csv"):
                     df = read_csv_file(up_file)
-                    file_sheets[filename] = df
                     all_dfs.append(df)
                 elif filename.lower().endswith(".zip"):
                     with zipfile.ZipFile(up_file) as zf:
                         dfs = extract_csv_from_zip(zf)
-                        for i, df in enumerate(dfs, 1):
-                            sheet_name = f"{filename}_file{i}"
-                            file_sheets[sheet_name] = df
-                            all_dfs.append(df)
+                        all_dfs.extend(dfs)
             if not all_dfs:
                 st.error("Aucun fichier CSV n'a été trouvé.")
                 return
@@ -68,8 +63,6 @@ def main():
             buffer = BytesIO()
             with pd.ExcelWriter(buffer, engine="openpyxl") as writer:
                 merged.to_excel(writer, sheet_name="Fusion", index=False)
-                for sheet, df in file_sheets.items():
-                    df.to_excel(writer, sheet_name=sheet[:31], index=False)
             buffer.seek(0)
             st.download_button(
                 "Télécharger le fichier Excel",


### PR DESCRIPTION
## Summary
- remove file_sheets dictionary and all per-file worksheet creation
- export only a single `Fusion` sheet
- clarify README that the resulting workbook contains one sheet

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684addfacdb0832db0b24195a851f34f