### PR TITLE
Calcule la moyenne conso par numero

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CSV/XLS Analyse
 
-Cette application Streamlit permet d’importer plusieurs fichiers CSV ou ZIP, de fusionner les données et de télécharger un fichier Excel contenant une seule feuille "Fusion" regroupant toutes les données.
+Cette application Streamlit permet d’importer plusieurs fichiers CSV ou ZIP, de fusionner les données et de télécharger un fichier Excel contenant une feuille "Fusion" regroupant toutes les lignes et une feuille "Moyenne conso DATA" cumulant les volumes par numéro d’utilisateur.
 
 ## Prérequis
 

--- a/app.py
+++ b/app.py
@@ -47,7 +47,6 @@ def compute_moyenne_conso(df: pd.DataFrame) -> pd.DataFrame:
         "Nom de la sous-rubrique",
         "Période de la facture",
         "Quantité ou volume",
-        "Nom de la rubrique de niveau 1",
         "Numéro de l’utilisateur",
         "Nom de l’utilisateur",
         "Prénom de l’utilisateur",
@@ -70,8 +69,8 @@ def compute_moyenne_conso(df: pd.DataFrame) -> pd.DataFrame:
     df["month"] = df["date"].dt.to_period("M")
     df["bytes"] = df["Quantité ou volume"].apply(parse_volume)
 
+    # Cumulate data per user number while keeping the main identity columns
     id_cols = [
-        "Nom de la rubrique de niveau 1",
         "Numéro de l’utilisateur",
         "Nom de l’utilisateur",
         "Prénom de l’utilisateur",
@@ -173,13 +172,13 @@ def main():
                 return
 
             merged = pd.concat(all_dfs, ignore_index=True)
-            echanges_df = filter_echanges(merged)
+            moyenne_df = compute_moyenne_conso(merged)
 
             buffer = BytesIO()
             with pd.ExcelWriter(buffer, engine="openpyxl") as writer:
                 merged.to_excel(writer, sheet_name="Fusion", index=False)
-                if not echanges_df.empty:
-                    echanges_df.to_excel(
+                if not moyenne_df.empty:
+                    moyenne_df.to_excel(
                         writer, sheet_name="Moyenne conso DATA", index=False
                     )
             buffer.seek(0)


### PR DESCRIPTION
## Summary
- synthesize volumes by user number in `compute_moyenne_conso`
- output aggregated data to the *Moyenne conso DATA* sheet
- mention the aggregation in the README

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684d34a937d0832db94a0bf86ec70ec1